### PR TITLE
Revert "Dependencies should not be a child of galaxy_info."

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,4 +6,4 @@ galaxy_info:
   min_ansible_version: 1.9
   categories:
     - ldap
-dependencies: []
+  dependencies: []


### PR DESCRIPTION
Reverts mkouhei/ansible-role-ldap#3

does not import Ansible galaxy.

```
Starting import 6908: role_name=ldap repo=mkouhei/ansible-role-ldap ref=
Retrieving Github repo mkouhei/ansible-role-ldap
Accessing branch: master
Parsing and validating meta/main.yml
Parsing galaxy_tags
Found galaxy_info.categories. Update meta/main.yml to use galaxy_info.galaxy_tags.
Parsing platforms
galaxy_info.platforms not defined in meta.main.yml. Must be an iterable list.
Adding dependencies
Parsing and validating README
Adding repo tags as role versions
Import completed
Status FAILED : warnings=1 errors=1 
```
