### PR TITLE
Revert "Revert "Dependencies should not be a child of galaxy_info.""

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,4 +6,4 @@ galaxy_info:
   min_ansible_version: 1.9
   categories:
     - ldap
-  dependencies: []
+dependencies: []


### PR DESCRIPTION
Reverts mkouhei/ansible-role-ldap#4

The PR is not related with this error.
