### PR TITLE
add base64 decode process for binary attribute.

### DIFF
--- a/library/ldap_attr
+++ b/library/ldap_attr
@@ -28,6 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from traceback import format_exc
 
+from base64 import b64decode
+
 import ldap
 import ldap.sasl
 
@@ -105,6 +107,10 @@ options:
         required: false
         description:
             - The password to use with C(bind_dn).
+    binary:
+        required: false
+        description:
+            - If true, do b64decode values.
 """
 
 
@@ -158,6 +164,7 @@ def main():
             'start_tls': dict(default='false', choices=BOOLEANS),
             'bind_dn': dict(default=None),
             'bind_pw': dict(default='', no_log=True),
+            'binary': dict(default='false', choices=BOOLEANS)
         },
         supports_check_mode=True,
     )
@@ -182,6 +189,7 @@ class LdapAttr(object):
         self.start_tls = self.module.boolean(self.module.params['start_tls'])
         self.bind_dn = self._utf8_param('bind_dn')
         self.bind_pw = self._utf8_param('bind_pw')
+        self.binary = self.module.boolean(self.module.params['binary'])
 
         self._connection = None
 
@@ -201,7 +209,10 @@ class LdapAttr(object):
         if not (isinstance(values, list) and all(isinstance(value, basestring) for value in values)):
             self.module.fail_json(msg="values must be a string or list of strings.")
 
-        return map(self._force_utf8, values)
+        return [self._force_utf8(self._convert_binary_data(x)) for x in values]
+
+    def _convert_binary_data(self, value):
+        return b64decode(value) if self.binary else value
 
     def _force_utf8(self, value):
         """ If value is unicode, encode to utf-8. """

--- a/library/ldap_entry
+++ b/library/ldap_entry
@@ -28,6 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from traceback import format_exc
 
+from base64 import b64decode
+
 import ldap
 import ldap.modlist
 import ldap.sasl
@@ -94,6 +96,10 @@ options:
         required: false
         description:
             - The password to use with C(bind_dn).
+    binary_attribute:
+        required: false
+        description:
+            - The list of binary attribute names.
 """
 
 
@@ -124,6 +130,7 @@ def main():
             'start_tls': dict(default='false', choices=BOOLEANS),
             'bind_dn': dict(default=None),
             'bind_pw': dict(default='', no_log=True),
+            'binary_attribute': dict(default=[]),
         },
         check_invalid_arguments=False,
         supports_check_mode=True,
@@ -149,6 +156,7 @@ class LdapEntry(object):
         self.start_tls = self.module.boolean(self.module.params['start_tls'])
         self.bind_dn = self._utf8_param('bind_dn')
         self.bind_pw = self._utf8_param('bind_pw')
+        self.binary_attribute = self.module.params['binary_attribute']
         self.attrs = {}
 
         self._load_attrs()
@@ -173,7 +181,10 @@ class LdapEntry(object):
         if not (isinstance(values, list) and all(isinstance(value, basestring) for value in values)):
             self.module.fail_json(msg="{} must be a string or list of strings.".format(name))
 
-        return map(self._force_utf8, values)
+        return [self._force_utf8(self._convert_binary_data(name, x)) for x in values]
+
+    def _convert_binary_data(self, name, value):
+        return b64decode(value) if name in self.binary_attribute else value
 
     def _force_utf8(self, value):
         """ If value is unicode, encode to utf-8. """


### PR DESCRIPTION
(日本語で失礼します)

このmoduleを利用してActive Directoryにスキーマの追加などしようとしたところ、schemaIDGUIDのような(base64 encodeされた)バイナリ属性がうまく設定できず、最終的にデコードされたバイナリデータをYAMLには直接落とさず処理の直前でインメモリにデコードすることで対処して解決しました。

https://github.com/ansible/ansible/issues/7957 の通り、'last mile'で処理せざるを得ないと思われるので、モジュールのパラメータとしてバイナリ属性に対応できるよう修正してみました。
