### PR TITLE
Fix "Bad parameter ..." errors with Ansible 2.2

### DIFF
--- a/library/ldap_attr
+++ b/library/ldap_attr
@@ -201,7 +201,7 @@ class LdapAttr(object):
         if not (isinstance(values, list) and all(isinstance(value, basestring) for value in values)):
             self.module.fail_json(msg="values must be a string or list of strings.")
 
-        return map(self._force_utf8, values)
+        return list(map(self._force_utf8, values))
 
     def _force_utf8(self, value):
         """ If value is unicode, encode to utf-8. """

--- a/library/ldap_entry
+++ b/library/ldap_entry
@@ -173,7 +173,7 @@ class LdapEntry(object):
         if not (isinstance(values, list) and all(isinstance(value, basestring) for value in values)):
             self.module.fail_json(msg="{} must be a string or list of strings.".format(name))
 
-        return map(self._force_utf8, values)
+        return list(map(self._force_utf8, values))
 
     def _force_utf8(self, value):
         """ If value is unicode, encode to utf-8. """


### PR DESCRIPTION
Resolves "Bad parameter to an ldap routine" errors that start to appear when running these modules against Ansible >=2.2. I've tested this against Ansible 2.1 and 2.2, and it works with both.